### PR TITLE
Fix: 비밀번호 변경 모달에서 에러 메시지 위치 이동

### DIFF
--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -234,7 +234,6 @@ function MyPage() {
                                 label="새 비밀번호"
                                 value={editPassword}
                                 onChange={handleEditPasswordChange}
-                                error={passwordMatchError}
                             />
                             {showEditPassword ? (
                                 <FaRegEye
@@ -255,13 +254,18 @@ function MyPage() {
                             )}
                         </div>
 
+                        {passwordMatchError && (
+                            <p className='field-error-message' role='alert'>
+                                {passwordMatchError}
+                            </p>
+                        )}
+
                         <div className='confirm-edit-password'>
                             <FormGroup 
                                 type={showConfirmEditPassword ? "text" : "password"} 
                                 label="새 비밀번호 확인"
                                 value={confirmEditPassword}
                                 onChange={handleConfirmEditPasswordChange}
-                                error={passwordMatchError}
                             />
                             {showConfirmEditPassword ? (
                                 <FaRegEye
@@ -281,6 +285,12 @@ function MyPage() {
                                 />
                             )}
                         </div>
+
+                        {passwordMatchError && (
+                            <p className='field-error-message' role='alert'>
+                                {passwordMatchError}
+                            </p>
+                        )}
                     </div>
                     <hr />
                 </Modal>

--- a/src/styles/mypage.scss
+++ b/src/styles/mypage.scss
@@ -272,6 +272,13 @@
                 cursor: pointer;
             }
         }
+
+        .field-error-message {
+            margin-top: 6px;
+            font-size: 12px;
+            color: $red-500;
+            text-align: center;
+        }
     }
 
     .delete-user-form {


### PR DESCRIPTION
## PR 제목
<!-- 예: [Feat] 로그인 기능 추가 -->
- [Fix]: 비밀번호 변경 모달에서 에러 메시지 위치 이동

---

## 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 비밀번호 변경 모달에서 입력란 하단에 에러 메시지가 뜨게 함
- 에러 메시지가 뜰 때 안구 모양의 버튼이 아래로 내려가는 문제 해결

---

## 체크리스트
[ ㅇ ] 코드에 불필요한 console.log 제거
[ ㅇ ] 로컬에서 정상 동작 확인
[ ] 테스트 코드 통과
[ ㅇ ] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

---

## 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. ex) Closes #123 -->
Closes #30

---

## 스크린샷 (선택)
 