### PR TITLE
[Feat] 장바구니 삭제기능 추가 / 구매하기 > checkout로 구매리스트 데이터 전송 구현

### DIFF
--- a/src/api/cart.js
+++ b/src/api/cart.js
@@ -82,3 +82,25 @@ export async function updateCartItem(productId, quantity) {
     };
   }
 }
+
+// 장바구니 아이템 삭제 (DELETE /cart/items/{productId}/)
+export async function deleteCartItem(productId) {
+  try {
+    const res = await api.delete(`/cart/items/${productId}/`);
+    return res.data;
+  } catch (e) {
+    if (e.response) {
+      throw {
+        message:
+          e.response.data?.error ||
+          "장바구니에서 상품을 삭제하는 중 오류가 발생했습니다.",
+        code: e.response.status,
+      };
+    }
+
+    throw {
+      message: "네트워크 오류가 발생했습니다. 다시 시도해주세요.",
+      code: "NETWORK_ERROR",
+    };
+  }
+}

--- a/src/hooks/useBuyMove.js
+++ b/src/hooks/useBuyMove.js
@@ -1,0 +1,47 @@
+import { useNavigate } from "react-router-dom";
+import { getCart } from "../api/cart";
+import { alertError } from "../utils/alert";
+
+function useBuyMove() {
+  const navigate = useNavigate();
+
+  async function navigateToCheckout(products) {
+    try {
+      // 최신 장바구니 또는 재고 정보 조회
+      const res = await getCart();
+      const latestItems = Array.isArray(res[0]?.items) ? res[0].items : [];
+
+      // 재고 체크
+      for (const product of products) {
+        const latest = latestItems.find(
+          (item) => item.product_id === product.book.id
+        );
+
+        if (!latest) {
+          alertError(
+            "상품 구매 오류",
+            `${product.book.name} 상품 정보를 찾을 수 없습니다.`
+          );
+          return;
+        }
+
+        if (product.quantity > latest.product_stock) {
+          alertError(
+            "상품 재고 부족",
+            `${product.book.name} 상품 재고가 부족합니다. 재고: ${latest.product_stock}`
+          );
+          return;
+        }
+      }
+
+      // 이상 없으면 checkout 페이지로 이동
+      navigate("/checkout", { state: { buyProducts: products } });
+    } catch {
+      alertError("상품 구매 오류", "재고 확인 중 문제가 발생했습니다.");
+    }
+  }
+
+  return navigateToCheckout;
+}
+
+export default useBuyMove;

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -134,7 +134,7 @@ const BookListRowLoop = ({ books, onCardClick }) => {
             setCurrentIndex((prev) => (prev + 1) % books.length);
         }, 4000);
         return () => clearInterval(autoScrollIntervalRef.current);
-    }, [isAutoScrolling, books.length]);
+    }, [ books.length]);
 
     // index 바뀔 때 스크롤 (기존 로직 유지)
     useEffect(() => {
@@ -145,7 +145,7 @@ const BookListRowLoop = ({ books, onCardClick }) => {
                 behavior: "smooth",
             });
         }
-    }, [currentIndex, books.length]);
+    }, [books.length]);
 
     // 마우스 휠로 이동 (기존 로직 유지)
     useEffect(() => {

--- a/src/stores/cartStore.js
+++ b/src/stores/cartStore.js
@@ -5,8 +5,12 @@ const useCartStore = create((set, get) => ({
   cartCount: 0, //장바구니 개수
 
   // API 호출 후 장바구니 초기화
-  setCartItems: (items) => set({ cartItems: items }),
-  
+  setCartItems: (items) =>
+    set({
+      cartItems: items,
+      cartCount: items.length,
+    }),
+
   // api 호출 후 장바구니 개수 저장
   setCartCount: (count) => set({ cartCount: count }),
 

--- a/src/stores/userStore.js
+++ b/src/stores/userStore.js
@@ -17,18 +17,7 @@ const useUserStore = create((set) => ({
     }
   },
   // 로그인 성공 시 사용자 상태 저장
-
-
   setUser: (userData) => set({ user: userData, justLoggedOut: false }),
-  
-  // 로딩 상태 변경
-  setLoading: (loading) => set({ loading }),
-
-  // 에러 상태 변경
-  setError: (error) => set({ error }),
-    
-  // 로그인 성공 시 사용자 상태 저장
-  setUser: (userData) => set({ user: userData }),
 
   // 로딩 상태 변경
   setLoading: (loading) => set({ loading }),

--- a/src/styles/cdh/book-Detail.scss
+++ b/src/styles/cdh/book-Detail.scss
@@ -158,38 +158,38 @@ $extra-light-green: #B0E0C0;
 }
 
 //  가격 정보 (포인트 라인 두께 및 글씨 크기 수정) 
-.book-price {
-  background: linear-gradient(135deg, white, $anti-flash-white, lighten($pistachio, 25%));
-  padding: 1.5rem;
+// .book-price {
+//   background: linear-gradient(135deg, white, $anti-flash-white, lighten($pistachio, 25%));
+//   padding: 1.5rem;
   
-  border-radius: 0 12px 12px 0; 
-  // 수정: 포인트 라인 두께를 3px로 얇게 조정 
-  border-left: 3px solid $caribbean-green;
-  border-right: none; 
+//   border-radius: 0 12px 12px 0; 
+//   // 수정: 포인트 라인 두께를 3px로 얇게 조정 
+//   border-left: 3px solid $caribbean-green;
+//   border-right: none; 
 
-  box-shadow: 
-    0 4px 12px rgba(0, 0, 0, 0.05),
-    0 2px 8px $vibrant-shadow;
-  position: relative;
-  max-width: 320px; 
-  width: 100%; 
+//   box-shadow: 
+//     0 4px 12px rgba(0, 0, 0, 0.05),
+//     0 2px 8px $vibrant-shadow;
+//   position: relative;
+//   max-width: 320px; 
+//   width: 100%; 
 
-  &::before {
-    display: none; 
-  }
+//   &::before {
+//     display: none; 
+//   }
 
-  .original-price {
-    // 수정: 가격 글씨 크기 축소 (1.1rem -> 1.05rem) 
-    font-size: 1.05rem;
-    font-weight: bold;
-    background: linear-gradient(135deg, $bangladesh-green, $basil-green);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    display: flex;
-    align-items: center;
-  }
-}
+//   .original-price {
+//     // 수정: 가격 글씨 크기 축소 (1.1rem -> 1.05rem) 
+//     font-size: 1.05rem;
+//     font-weight: bold;
+//     background: linear-gradient(135deg, $bangladesh-green, $basil-green);
+//     -webkit-background-clip: text;
+//     -webkit-text-fill-color: transparent;
+//     background-clip: text;
+//     display: flex;
+//     align-items: center;
+//   }
+// }
 
 //  하단 영역 (스타일 유지) 
 .book-detail-bottom {

--- a/src/styles/cdh/bookmainpage.scss
+++ b/src/styles/cdh/bookmainpage.scss
@@ -13,11 +13,11 @@ $warm-white: #fdfaf6;
 $light-gray: #f5f5f5;
 
 // ===== Reset =====
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
+// * {
+//   margin: 0;
+//   padding: 0;
+//   box-sizing: border-box;
+// }
 
 // ===== Layout =====
 .main-page-container {
@@ -26,11 +26,11 @@ $light-gray: #f5f5f5;
   line-height: 1.6;
 }
 
-.base-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 2rem 1rem;
-}
+// .base-container {
+//   max-width: 1200px;
+//   margin: 0 auto;
+//   padding: 2rem 1rem;
+// }
 
 // ===== Banner (MainBanner.jsx) =====
 .main-banner {


### PR DESCRIPTION
## PR 제목
<!-- 예: [Feat] 로그인 기능 추가 -->
- [Feat] 장바구니 삭제기능 추가 / 검색페이지,장바구니 구매하기 > checkout로 구매리스트 데이터 전송 구현

---

## 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 장바구니 삭제 기능
- checkout으로 상품리스트 데이터 가공 + api로 재고검증 후 데이터 전송 커스텀 훅 구현
- 장바구니 개수 전역상태에서 setItems에서 자동으로 cartCount 변하게 수정 완료
- 검색페이지에서 로그인 안한 사용자들 장바구니/구매하기 로그인 필요 알림창 추가 및 이후 이벤트 차단
- 검색페이지 > 상품리스트에서 재고 없으면 바로구매 버튼 품절 + disabled 구현

---

## 체크리스트
[ o ] 코드에 불필요한 console.log 제거
[ o ] 로컬에서 정상 동작 확인
[ o ] 테스트 코드 통과
[ o ] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

---

## 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. ex) Closes #123 -->
Closes #123 

---

## 스크린샷 (선택)
 