### PR TITLE
[Fix] 바로구매 할 때 장바구니 로직 수정 및 image 키값 수정

### DIFF
--- a/src/components/common/BookCard.jsx
+++ b/src/components/common/BookCard.jsx
@@ -61,7 +61,7 @@ export const BookCardRow = memo(function BookCardRow({
 
       <div className="book-card-row-image">
         <img
-          src={book.image_url || DEFAULT_IMAGE}
+          src={book.image || DEFAULT_IMAGE}
           alt={book.name}
           onError={handleImgError}
         />

--- a/src/hooks/useBuyMove.js
+++ b/src/hooks/useBuyMove.js
@@ -7,7 +7,9 @@ function useBuyMove() {
 
   async function navigateToCheckout(products, flag) {
     if (flag === "direct") {
-      navigate("/checkout", { state: { buyProducts: products } });
+      navigate("/checkout", {
+        state: { buyProducts: products, path: "direct" },
+      });
       return;
     }
 
@@ -32,7 +34,7 @@ function useBuyMove() {
       });
 
       // 이상 없으면 checkout 페이지로 이동
-      navigate("/checkout", { state: { buyProducts: products } });
+      navigate("/checkout", { state: { buyProducts: products, path: "cart" } });
     } catch {
       alertError("상품 구매 오류", "재고 확인 중 문제가 발생했습니다.");
     }

--- a/src/pages/BookDetail.jsx
+++ b/src/pages/BookDetail.jsx
@@ -12,276 +12,275 @@ import useBuyMove from "../hooks/useBuyMove";
 const DEFAULT_IMAGE = "/no-image.jpg";
 
 const formatPrice = (price) => {
-    const numericPrice = Number(price);
-    if (isNaN(numericPrice)) {
-        return "가격 미정";
-    }
-    return numericPrice.toLocaleString("ko-KR", {
-        maximumFractionDigits: 0,
-    });
+  const numericPrice = Number(price);
+  if (isNaN(numericPrice)) {
+    return "가격 미정";
+  }
+  return numericPrice.toLocaleString("ko-KR", {
+    maximumFractionDigits: 0,
+  });
 };
 
 function BookDetail() {
-    const { id } = useParams();
+  const { id } = useParams();
 
-    const [bookDetail, setBookDetail] = useState(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(null);
+  const [bookDetail, setBookDetail] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-    // 💡 [수정] cartItems (현재 장바구니 목록)와 setCartItems 액션을 모두 가져옵니다.
-    const cartItems = useCartStore((state) => state.cartItems);
-    const setStoreCartItems = useCartStore((state) => state.setCartItems);
-    
-    const navigateToCheckout = useBuyMove();
+  // 💡 [수정] cartItems (현재 장바구니 목록)와 setCartItems 액션을 모두 가져옵니다.
+  const cartItems = useCartStore((state) => state.cartItems);
+  const setStoreCartItems = useCartStore((state) => state.setCartItems);
 
-    useEffect(() => {
-        if (!id) {
-            setError("도서 ID가 유효하지 않습니다.");
-            setLoading(false);
-            return;
-        }
+  const navigateToCheckout = useBuyMove();
 
-        const loadBookDetail = async () => {
-            try {
-                setLoading(true);
-                setError(null);
-                const res = await getProductItem(id);
-                setBookDetail(res);
-            } catch (e) {
-                console.error(`도서(ID: ${id}) 정보 불러오기 실패 : `, e);
-                setError(
-                    e.message || "도서 상세 정보를 불러오는 중 오류가 발생했습니다."
-                );
-            } finally {
-                setLoading(false);
-            }
-        };
-
-        loadBookDetail();
-    }, [id]);
-
-    // 로딩, 에러, 데이터 없음 처리 (기존 코드 유지)
-    if (loading)
-        return (
-            <div className="book-detail-page">
-                <div className="base-container">
-                    <main className="book-detail-container">
-                        <p>도서 정보를 불러오는 중입니다...</p>
-                    </main>
-                </div>
-            </div>
-        );
-
-    if (error)
-        return (
-            <div className="book-detail-page">
-                <div className="base-container">
-                    <main className="book-detail-container">
-                        <p className="error-message">오류 발생: {error}</p>
-                    </main>
-                </div>
-            </div>
-        );
-
-    if (!bookDetail)
-        return (
-            <div className="book-detail-page">
-                <div className="base-container">
-                    <main className="book-detail-container">
-                        <p>요청하신 도서 정보를 찾을 수 없습니다.</p>
-                    </main>
-                </div>
-            </div>
-        );
-
-    const book = bookDetail;
-
-    // ... (Description 처리 로직은 그대로 유지) ...
-    const descriptionLines = book.description
-        ? book.description
-            .replace(/<br\s*\/?>/gi, "\n")
-            .replace(/<\/p>/gi, "\n")
-            .replace(/<\/div>/gi, "\n")
-            .replace(/\n\s*\n/g, "\n")
-            .split("\n")
-            .filter((line) => line.trim() !== "")
-        : [];
-
-    const PREVIEW_LINE_COUNT = 3;
-    const previewLines = descriptionLines.slice(0, PREVIEW_LINE_COUNT);
-    const previewDescription = previewLines.join("\n");
-    const remainingLines = descriptionLines.slice(PREVIEW_LINE_COUNT);
-    const remainingDescription = remainingLines.join("\n");
-
-    let bottomContent = null;
-
-    if (remainingDescription) {
-        bottomContent = <p className="description-rest">{remainingDescription}</p>;
-    } else {
-        const formattedPrice = formatPrice(book.price);
-        const fallbackText = `${
-            book.name || "이 도서"
-        }은 독자 여러분들의 많은 관심과 기대를 바라며 정가: ${formattedPrice}원에 기다리고 있습니다.`;
-
-        bottomContent = (
-            <div className="book-metadata-fallback">
-                <p className="fallback-message">{fallbackText}</p>
-            </div>
-        );
+  useEffect(() => {
+    if (!id) {
+      setError("도서 ID가 유효하지 않습니다.");
+      setLoading(false);
+      return;
     }
-    // ... (Description 처리 로직 끝) ...
 
-    // 장바구니 추가 핸들러 (API 호출 및 Zustand 갱신)
-    const handleCartAdd = async () => {
-        // 💡 1. 장바구니 중복 체크 로직
-        const existingItem = cartItems.find(
-            // item.book.id와 현재 도서 ID를 비교 (타입이 다를 수 있으므로 toString()으로 비교)
-            (item) => item.book.id.toString() === book.id.toString()
+    const loadBookDetail = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const res = await getProductItem(id);
+        setBookDetail(res);
+      } catch (e) {
+        console.error(`도서(ID: ${id}) 정보 불러오기 실패 : `, e);
+        setError(
+          e.message || "도서 상세 정보를 불러오는 중 오류가 발생했습니다."
         );
-
-        if (existingItem) {
-            // 중복일 경우 알림을 띄우고 API 호출을 막습니다.
-            await alertError(
-                "장바구니 오류",
-                `선택하신 도서(${book.name})는 이미 장바구니에 담겨 있습니다.`,
-                "확인"
-            );
-            return; 
-        }
-
-        // 2. 장바구니 담기 확인
-        const alert = await alertComfirm(
-            "장바구니에 담겠습니까?",
-            "예를 누르면 장바구니에 상품이 담깁니다"
-        );
-        if (!alert.isConfirmed) return;
-
-        // 3. API 호출 및 상태 갱신 (중복이 아닐 경우)
-        try {
-            await addCart({ productId: book.id, quantity: 1 });
-
-            // 장바구니 상태 갱신: 최신 장바구니 목록을 서버에서 다시 가져와 스토어에 반영
-            const res = await getCart();
-            const items = Array.isArray(res[0]?.items) ? res[0].items : [];
-
-            // API 응답 구조를 스토어 형식에 맞게 매핑
-            const mappedItems = items.map((item) => ({
-                book: {
-                    id: item.product_id,
-                    name: item.product_name,
-                    category: item.product_category,
-                    author: item.product_author,
-                    publisher: item.product_publisher,
-                    price: Number(item.product_price),
-                    stock: item.product_stock,
-                    image_url: item.product_image,
-                },
-                quantity: item.quantity,
-            }));
-
-            setStoreCartItems(mappedItems);
-
-            await alertSuccess(
-                "장바구니",
-                `선택하신 도서(${book.name})가 장바구니에 담겼습니다.`
-            );
-        } catch (e) {
-            console.error("장바구니 추가 실패:", e);
-            alertError(
-                "장바구니 오류",
-                "상품을 장바구니에 추가하는 중 오류가 발생했습니다."
-            );
-        }
+      } finally {
+        setLoading(false);
+      }
     };
 
-    // 구매하기 핸들러 (useBuyMove 연결)
-    const handlebuyAdd = async () => {
-        const alert = await alertComfirm(
-            "상품을 구매하시겠습니까?",
-            "예를 누르면 상품구매를 진행합니다"
-        );
-        if (!alert.isConfirmed) return;
+    loadBookDetail();
+  }, [id]);
 
-        const productsToBuy = [
-            {
-                book: book,
-                quantity: 1,
-            },
-        ];
-
-        console.log(`즉시 구매 이동 호출: 도서 ID ${book.id}`);
-        navigateToCheckout(productsToBuy, "direct");
-    };
-
+  // 로딩, 에러, 데이터 없음 처리 (기존 코드 유지)
+  if (loading)
     return (
-        <>
-            <div className="book-detail-page">
-                <div className="base-container">
-                    <main className="book-detail-container">
-                        <div className="book-detail-image">
-                            <img
-                                src={book.image || DEFAULT_IMAGE} 
-                                alt={book.name}
-                                onError={(e) => {
-                                    e.currentTarget.src = DEFAULT_IMAGE;
-                                }}
-                            />
-                        </div>
-
-                        <div className="book-detail">
-                            <div className="book-detail-up">
-                                <h1>{book.name}</h1>
-                                <p>
-                                    저자: {book.author} | 출판사: {book.publisher}
-                                </p>
-                            </div>
-
-                            <div className="book-detail-bottom">
-                                <section className="book-detail-description">
-                                    <h2 className="book-introduction">소 개</h2>
-                                    <p className="description-preview">{previewDescription}</p>
-                                </section>
-
-                                <div className="bottom-flex-wrapper">
-                                    <div className="price-area-wrapper">
-                                        <section className="book-price">
-                                            <span className="original-price">
-                                                가격: {formatPrice(book.price)}원
-                                            </span>
-                                        </section>
-                                    </div>
-
-                                    <div className="book-actions">
-                                        <Button
-                                            onClick={handleCartAdd}
-                                            size="lg"
-                                            variant="secondary"
-                                        >
-                                            장바구니
-                                        </Button>
-                                        <Button onClick={handlebuyAdd} size="lg" variant="primary">
-                                            구매하기
-                                        </Button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </main>
-
-                    {book.description && (
-                        <section className="book-summary-section full-width-section">
-                            <h2 className="book-summary">상세 정보</h2>
-                            {bottomContent}
-
-                            {book.summary && (
-                                <p className="summary-original">{book.summary}</p>
-                            )}
-                        </section>
-                    )}
-                </div>
-            </div>
-        </>
+      <div className="book-detail-page">
+        <div className="base-container">
+          <main className="book-detail-container">
+            <p>도서 정보를 불러오는 중입니다...</p>
+          </main>
+        </div>
+      </div>
     );
+
+  if (error)
+    return (
+      <div className="book-detail-page">
+        <div className="base-container">
+          <main className="book-detail-container">
+            <p className="error-message">오류 발생: {error}</p>
+          </main>
+        </div>
+      </div>
+    );
+
+  if (!bookDetail)
+    return (
+      <div className="book-detail-page">
+        <div className="base-container">
+          <main className="book-detail-container">
+            <p>요청하신 도서 정보를 찾을 수 없습니다.</p>
+          </main>
+        </div>
+      </div>
+    );
+
+  const book = bookDetail;
+
+  // ... (Description 처리 로직은 그대로 유지) ...
+  const descriptionLines = book.description
+    ? book.description
+        .replace(/<br\s*\/?>/gi, "\n")
+        .replace(/<\/p>/gi, "\n")
+        .replace(/<\/div>/gi, "\n")
+        .replace(/\n\s*\n/g, "\n")
+        .split("\n")
+        .filter((line) => line.trim() !== "")
+    : [];
+
+  const PREVIEW_LINE_COUNT = 3;
+  const previewLines = descriptionLines.slice(0, PREVIEW_LINE_COUNT);
+  const previewDescription = previewLines.join("\n");
+  const remainingLines = descriptionLines.slice(PREVIEW_LINE_COUNT);
+  const remainingDescription = remainingLines.join("\n");
+
+  let bottomContent = null;
+
+  if (remainingDescription) {
+    bottomContent = <p className="description-rest">{remainingDescription}</p>;
+  } else {
+    const formattedPrice = formatPrice(book.price);
+    const fallbackText = `${
+      book.name || "이 도서"
+    }은 독자 여러분들의 많은 관심과 기대를 바라며 정가: ${formattedPrice}원에 기다리고 있습니다.`;
+
+    bottomContent = (
+      <div className="book-metadata-fallback">
+        <p className="fallback-message">{fallbackText}</p>
+      </div>
+    );
+  }
+  // ... (Description 처리 로직 끝) ...
+
+  // 장바구니 추가 핸들러 (API 호출 및 Zustand 갱신)
+  const handleCartAdd = async () => {
+    // 💡 1. 장바구니 중복 체크 로직
+    const existingItem = cartItems.find(
+      // item.book.id와 현재 도서 ID를 비교 (타입이 다를 수 있으므로 toString()으로 비교)
+      (item) => item.book.id.toString() === book.id.toString()
+    );
+
+    if (existingItem) {
+      // 중복일 경우 알림을 띄우고 API 호출을 막습니다.
+      await alertError(
+        "장바구니 오류",
+        `선택하신 도서(${book.name})는 이미 장바구니에 담겨 있습니다.`,
+        "확인"
+      );
+      return;
+    }
+
+    // 2. 장바구니 담기 확인
+    const alert = await alertComfirm(
+      "장바구니에 담겠습니까?",
+      "예를 누르면 장바구니에 상품이 담깁니다"
+    );
+    if (!alert.isConfirmed) return;
+
+    // 3. API 호출 및 상태 갱신 (중복이 아닐 경우)
+    try {
+      await addCart({ productId: book.id, quantity: 1 });
+
+      // 장바구니 상태 갱신: 최신 장바구니 목록을 서버에서 다시 가져와 스토어에 반영
+      const res = await getCart();
+      const items = Array.isArray(res[0]?.items) ? res[0].items : [];
+
+      // API 응답 구조를 스토어 형식에 맞게 매핑
+      const mappedItems = items.map((item) => ({
+        book: {
+          id: item.product_id,
+          name: item.product_name,
+          category: item.product_category,
+          author: item.product_author,
+          publisher: item.product_publisher,
+          price: Number(item.product_price),
+          stock: item.product_stock,
+          image_url: item.product_image,
+        },
+        quantity: item.quantity,
+      }));
+
+      setStoreCartItems(mappedItems);
+
+      await alertSuccess(
+        "장바구니",
+        `선택하신 도서(${book.name})가 장바구니에 담겼습니다.`
+      );
+    } catch (e) {
+      console.error("장바구니 추가 실패:", e);
+      alertError(
+        "장바구니 오류",
+        "상품을 장바구니에 추가하는 중 오류가 발생했습니다."
+      );
+    }
+  };
+
+  // 구매하기 핸들러 (useBuyMove 연결)
+  const handlebuyAdd = async () => {
+    const alert = await alertComfirm(
+      "상품을 구매하시겠습니까?",
+      "예를 누르면 상품구매를 진행합니다"
+    );
+    if (!alert.isConfirmed) return;
+
+    const productsToBuy = [
+      {
+        book: book,
+        quantity: 1,
+      },
+    ];
+
+    navigateToCheckout(productsToBuy, "direct");
+  };
+
+  return (
+    <>
+      <div className="book-detail-page">
+        <div className="base-container">
+          <main className="book-detail-container">
+            <div className="book-detail-image">
+              <img
+                src={book.image || DEFAULT_IMAGE}
+                alt={book.name}
+                onError={(e) => {
+                  e.currentTarget.src = DEFAULT_IMAGE;
+                }}
+              />
+            </div>
+
+            <div className="book-detail">
+              <div className="book-detail-up">
+                <h1>{book.name}</h1>
+                <p>
+                  저자: {book.author} | 출판사: {book.publisher}
+                </p>
+              </div>
+
+              <div className="book-detail-bottom">
+                <section className="book-detail-description">
+                  <h2 className="book-introduction">소 개</h2>
+                  <p className="description-preview">{previewDescription}</p>
+                </section>
+
+                <div className="bottom-flex-wrapper">
+                  <div className="price-area-wrapper">
+                    <section className="book-price">
+                      <span className="original-price">
+                        가격: {formatPrice(book.price)}원
+                      </span>
+                    </section>
+                  </div>
+
+                  <div className="book-actions">
+                    <Button
+                      onClick={handleCartAdd}
+                      size="lg"
+                      variant="secondary"
+                    >
+                      장바구니
+                    </Button>
+                    <Button onClick={handlebuyAdd} size="lg" variant="primary">
+                      구매하기
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </main>
+
+          {book.description && (
+            <section className="book-summary-section full-width-section">
+              <h2 className="book-summary">상세 정보</h2>
+              {bottomContent}
+
+              {book.summary && (
+                <p className="summary-original">{book.summary}</p>
+              )}
+            </section>
+          )}
+        </div>
+      </div>
+    </>
+  );
 }
 
 export default BookDetail;

--- a/src/pages/CartPage.jsx
+++ b/src/pages/CartPage.jsx
@@ -59,7 +59,7 @@ function CartPage() {
             publisher: item.product_publisher,
             price: Number(item.product_price),
             stock: item.product_stock,
-            image_url: item.product_image,
+            image: item.product_image,
           },
           quantity: item.quantity,
         }));

--- a/src/pages/CheckoutPage.jsx
+++ b/src/pages/CheckoutPage.jsx
@@ -100,7 +100,7 @@ function CheckoutPage() {
         author: item.book.author,
         publisher: item.book.publisher,
         price: Number(item.book.price || 0),
-        image_url: item.book.image,
+        image: item.book.image,
         isSoldOut: item.book.stock === 0,
       })),
     [buyProducts]

--- a/src/pages/CheckoutPage.jsx
+++ b/src/pages/CheckoutPage.jsx
@@ -9,7 +9,7 @@ import { Link, useNavigate, useLocation } from "react-router-dom";
 import { BookListRow } from "../components/common/BookListRow";
 import phoneFormat from "../utils/phoneFormat";
 import useCartStore from "../stores/cartStore";
-import { getCart } from "../api/cart";
+import { addCart, getCart } from "../api/cart";
 import { Radio } from "../components/common/CheckRadio";
 
 const METHODS = ["카드", "계좌이체", "휴대폰 결제"];
@@ -23,16 +23,22 @@ function CheckoutPage() {
 
   // ✅ CartPage에서 넘어온 선택 상품들: [{ book, quantity }]
   const buyProducts = useMemo(
-    () => (Array.isArray(location.state?.buyProducts) ? location.state.buyProducts : []),
+    () =>
+      Array.isArray(location.state?.buyProducts)
+        ? location.state.buyProducts
+        : [],
     [location.state]
-  )
+  );
+
+  const buyPath = location.state.path;
 
   // 주문 API에 보낼 선택 아이템 ID 배열
   // 백엔드가 '장바구니 아이템 ID'를 요구한다면 여기에서 p.cart_item_id 같은 필드로 바꾸세요.
   const selectedItemIds = useMemo(
-    () => buyProducts
-      .map((p) => p.book?.id ?? p.id) // book.id 우선, 없으면 p.id
-      .filter(Boolean),
+    () =>
+      buyProducts
+        .map((p) => p.book?.id ?? p.id) // book.id 우선, 없으면 p.id
+        .filter(Boolean),
     [buyProducts]
   );
 
@@ -47,11 +53,40 @@ function CheckoutPage() {
 
   // state가 없거나 비었으면 장바구니로 돌려보내기
   useEffect(() => {
-    if (!Array.isArray(buyProducts) || buyProducts.length === 0) {
-      alertError("선택된 상품이 없습니다.", "장바구니에서 상품을 선택해주세요.");
-      navigate("/cart", { replace: true });
-    }
-  }, [buyProducts, navigate]);
+    // direct로 진입한 경우에만 장바구니 추가
+    const autoAddToCartIfDirect = async () => {
+      if (buyPath === "direct" && buyProducts.length > 0) {
+        try {
+          // 현재 장바구니 상품 id 조회
+          const cartData = await getCart();
+          const cartId = Array.isArray(cartData[0]?.items)
+            ? cartData[0].items.map((item) => item.product_id)
+            : [];
+
+          // 선택상품 중 장바구니에 없는 것만 추가
+          await Promise.all(
+            buyProducts.map(async (item) => {
+              if (!cartId.includes(item.book.id)) {
+                await addCart({
+                  productId: item.book.id,
+                  quantity: item.quantity,
+                });
+              }
+            })
+          );
+          // 장바구니 상품 재적재 등 필요에 따라 추가
+        } catch (e) {
+          alertError(
+            "장바구니 추가 오류",
+            e.message || "장바구니에 상품을 담는 중 오류가 발생했습니다."
+          );
+          navigate("/cart", { replace: true });
+        }
+      }
+    };
+
+    autoAddToCartIfDirect();
+  }, [buyPath, buyProducts, navigate]);
 
   // 👉 BookListRow가 기대하는 형태로 매핑 (row 카드 규격)
   //    - image_url, name, price, id 등은 book 객체에서 꺼냄
@@ -65,7 +100,7 @@ function CheckoutPage() {
         author: item.book.author,
         publisher: item.book.publisher,
         price: Number(item.book.price || 0),
-        image_url: item.book.image_url,
+        image_url: item.book.image,
         isSoldOut: item.book.stock === 0,
       })),
     [buyProducts]
@@ -125,8 +160,8 @@ function CheckoutPage() {
           }
         }
 
-        setDisplayAddress(fullAddress);  // 최종 주소를 상태로 저장 input표시용
-        setAddress(fullAddress);   // 주소 검증용 state도 함께 갱신
+        setDisplayAddress(fullAddress); // 최종 주소를 상태로 저장 input표시용
+        setAddress(fullAddress); // 주소 검증용 state도 함께 갱신
       },
     }).open();
   };
@@ -153,11 +188,14 @@ function CheckoutPage() {
   };
 
   const onClickCancel = () => {
-    navigate("/cart")
-  }
+    navigate("/cart");
+  };
 
   const onConfirmPay = async () => {
-    const { isConfirmed } = await alertComfirm("결제 진행", `선택한 결제수단: ${method}\n계속 진행할까요?`);
+    const { isConfirmed } = await alertComfirm(
+      "결제 진행",
+      `선택한 결제수단: ${method}\n계속 진행할까요?`
+    );
     if (!isConfirmed) return;
 
     try {
@@ -181,26 +219,31 @@ function CheckoutPage() {
         method,
       });
 
-      await alertSuccess("주문 접수", `주문번호 #${order.order_number}로 접수되었습니다.\n결제상태: ${payment.status}\n결제금액: ${Number(payment.total_price||0).toLocaleString()}원`);
+      await alertSuccess(
+        "주문 접수",
+        `주문번호 #${order.order_number}로 접수되었습니다.\n결제상태: ${
+          payment.status
+        }\n결제금액: ${Number(payment.total_price || 0).toLocaleString()}원`
+      );
       // await alertSuccess("주문 접수", `주문번호로 접수되었습니다.`);
       // TODO: navigate(`/orders/${orderId}`);
 
-      const res = await getCart();
-      const items = Array.isArray(res[0]?.items) ? res[0].items : [];
-      const mapped = items.map((item) => ({
-        book: {
-          id: item.product_id,
-          name: item.product_name,
-          category: item.product_category,
-          author: item.product_author,
-          publisher: item.product_publisher,
-          price: Number(item.product_price),
-          stock: item.product_stock,
-          image_url: item.product_image,
-        },
-        quantity: item.quantity,
-      }));
-      setStoreCartItems(mapped);  // ✅ 헤더 카운트 갱신 포인트
+        const res = await getCart();
+        const items = Array.isArray(res[0]?.items) ? res[0].items : [];
+        const mapped = items.map((item) => ({
+          book: {
+            id: item.product_id,
+            name: item.product_name,
+            category: item.product_category,
+            author: item.product_author,
+            publisher: item.product_publisher,
+            price: Number(item.product_price),
+            stock: item.product_stock,
+            image_url: item.product_image,
+          },
+          quantity: item.quantity,
+        }));
+        setStoreCartItems(mapped); // ✅ 헤더 카운트 갱신 포인트
 
       const payload = {
         orderId,
@@ -213,14 +256,16 @@ function CheckoutPage() {
           name: p.book.name,
           price: Number(p.book.price || 0),
           qty: Number(p.quantity || 0),
-          image_url: p.book.image_url,
+          image_url: p.book.image,
         })),
       };
-
       sessionStorage.setItem("last_payment_success", JSON.stringify(payload));
       navigate("/checkout/success", { replace: true, state: payload });
     } catch (e) {
-      await alertError("결제 실패", e.message || "주문/결제 처리 중 문제가 발생했습니다.");
+      await alertError(
+        "결제 실패",
+        e.message || "주문/결제 처리 중 문제가 발생했습니다."
+      );
     } finally {
       setSubmitting(false);
       setOpenPayModal(false);
@@ -243,7 +288,9 @@ function CheckoutPage() {
               //   <button onClick={() => console.log("삭제:", book.id)}>삭제</button>
               // )}
               // ✅ 여기서 qtyMap으로 안전하게 수량 뱃지 표시
-              leftActions={(b) => <span className="qty-badge">x{qtyMap.get(b.id) || 0}</span>}
+              leftActions={(b) => (
+                <span className="qty-badge">x{qtyMap.get(b.id) || 0}</span>
+              )}
               // leftActions={(book) => (
               //   <input
               //     type="checkbox"
@@ -288,16 +335,11 @@ function CheckoutPage() {
               label="주소"
               value={displayAddress}
               onChange={(e) => {
-                  setDisplayAddress(e.target.value);
-                  setAddress(e.target.value);
-                }
-              }
+                setDisplayAddress(e.target.value);
+                setAddress(e.target.value);
+              }}
             />
-            <Button
-              variant="secondary"
-              size="md"
-              onClick={handleAddressSearch}
-            >
+            <Button variant="secondary" size="md" onClick={handleAddressSearch}>
               주소 검색
             </Button>
 
@@ -310,11 +352,7 @@ function CheckoutPage() {
               >
                 {submitting ? "처리 중..." : "결제하기"}
               </Button>
-              <Button
-                variant="secondary"
-                size="lg"
-                onClick={onClickCancel}
-              >
+              <Button variant="secondary" size="lg" onClick={onClickCancel}>
                 취소하기
               </Button>
             </div>
@@ -327,16 +365,16 @@ function CheckoutPage() {
             // onClose={() => !submitting && setOpenPayModal(false)}
             footer={
               <>
-                <Button 
-                  variant="secondary" 
+                <Button
+                  variant="secondary"
                   // onClick={() => setOpenPayModal(false)} disabled={submitting}
                   onClick={() => setOpenPayModal(false)}
                 >
                   취소
                 </Button>
-                <Button 
-                  variant="primary" 
-                  onClick={onConfirmPay} 
+                <Button
+                  variant="primary"
+                  onClick={onConfirmPay}
                   disabled={submitting}
                 >
                   {submitting ? "처리 중..." : "확인"}
@@ -359,7 +397,7 @@ function CheckoutPage() {
         </div>
       </div>
     </>
-  )
+  );
 }
 
 export default CheckoutPage;

--- a/src/pages/PaymentSuccessPage.jsx
+++ b/src/pages/PaymentSuccessPage.jsx
@@ -9,7 +9,7 @@ export default function PaymentSuccessPage() {
   const { state } = useLocation();
   const navigate = useNavigate();
   const [data, setData] = useState(null);
-
+  console.log(state);
   // state 우선 → 없으면 sessionStorage에서 백업 읽기
   useEffect(() => {
     if (state && typeof state === "object") {
@@ -28,7 +28,10 @@ export default function PaymentSuccessPage() {
 
   const subtotal = useMemo(() => {
     if (!data?.items) return 0;
-    return data.items.reduce((acc, it) => acc + (Number(it.price) || 0) * (Number(it.qty) || 0), 0);
+    return data.items.reduce(
+      (acc, it) => acc + (Number(it.price) || 0) * (Number(it.qty) || 0),
+      0
+    );
   }, [data]);
 
   if (!data) {
@@ -38,7 +41,10 @@ export default function PaymentSuccessPage() {
           <h1>결제가 완료되었습니다.</h1>
           <p className="dim">주문 정보가 확인되지 않아 홈으로 이동합니다.</p>
           <div className="actions">
-            <Button variant="primary" onClick={() => navigate("/", { replace: true })}>
+            <Button
+              variant="primary"
+              onClick={() => navigate("/", { replace: true })}
+            >
               홈으로
             </Button>
           </div>
@@ -53,7 +59,8 @@ export default function PaymentSuccessPage() {
         <div className="success-head">
           <h1>결제가 완료되었습니다 🎉</h1>
           <p className="dim">
-            주문번호 <b>#{data.orderId ?? "-"}</b> / 결제수단 {data.method ?? "-"} / 결제일{" "}
+            주문번호 <b>#{data.orderId ?? "-"}</b> / 결제수단{" "}
+            {data.method ?? "-"} / 결제일{" "}
             {data.when ? new Date(data.when).toLocaleString() : "-"}
           </p>
         </div>
@@ -102,13 +109,17 @@ export default function PaymentSuccessPage() {
 
         <div className="actions">
           <Link to="/orderlog">
-            <Button variant="primary" size="md">주문내역 보기</Button>
+            <Button variant="primary" size="md">
+              주문내역 보기
+            </Button>
           </Link>
           <Link to="/">
-            <Button variant="secondary" size="md">계속 쇼핑하기</Button>
+            <Button variant="secondary" size="md">
+              계속 쇼핑하기
+            </Button>
           </Link>
         </div>
       </div>
     </>
-  )
+  );
 }


### PR DESCRIPTION
## PR 제목
<!-- 예: [Feat] 로그인 기능 추가 -->
- [Fix] 바로구매 할 때 장바구니 로직 수정 및 image 키값 수정

---

## 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->
- 바로구매 버튼으로 구매페이지 오면 path로 direct || cart로 분기
- direct면 장바구니에 담기(전역상태 업데이트x) / 백엔드 로직이 장바구니에 담겨있어야함
- 구매페이지, 결제완료페이지 이미지 경로 수정

---

## 체크리스트
[ o ] 코드에 불필요한 console.log 제거
[ o ] 로컬에서 정상 동작 확인
[ o ] 테스트 코드 통과
[ o ] PR 제목이 규칙에 맞게 작성됨 (예: [Fix]/[Feat]/[Docs])

---

## 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. ex) Closes #123 -->
Closes #170 

---

## 스크린샷 (선택)
 